### PR TITLE
Uses the local documentation bundled with Unity

### DIFF
--- a/Default (Linux).sublime-settings
+++ b/Default (Linux).sublime-settings
@@ -1,0 +1,4 @@
+{
+  "use_local_url": false,
+  "local_url": ""
+}

--- a/Default (OSX).sublime-settings
+++ b/Default (OSX).sublime-settings
@@ -1,0 +1,4 @@
+{
+  "use_local_url": false,
+  "local_url": "file:///Applications/Unity/Documentation/en/ScriptReference/30_search.html"
+}

--- a/Default (Windows).sublime-settings
+++ b/Default (Windows).sublime-settings
@@ -1,0 +1,4 @@
+{
+  "use_local_url": false,
+  "local_url": "C:\\Program Files (x86)\\Unity\\Editor\\Data\\Documentation\\html\\en\\ScriptReference\\30_search.html"
+}

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -43,6 +43,55 @@
                             {
                                 "command": "open_file",
                                 "args": {
+                                    "file": "${packages}/Unity3DReference/Default (Windows).sublime-settings",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Settings - Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/Unity3DReference/Default (OSX).sublime-settings",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Settings - Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/Unity3DReference/Default (Linux).sublime-settings",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Settings - Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Unity3DReference.sublime-settings",
+                                    "platform": "Windows"
+                                },
+                                "caption": "Settings - User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Unity3DReference.sublime-settings",
+                                    "platform": "OSX"
+                                },
+                                "caption": "Settings - User"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {
+                                    "file": "${packages}/User/Unity3DReference.sublime-settings",
+                                    "platform": "Linux"
+                                },
+                                "caption": "Settings - User"
+                            },
+                            { "caption": "-" },
+                            {
+                                "command": "open_file",
+                                "args": {
                                     "file": "${packages}/Unity3DReference/Default.sublime-keymap",
                                     "platform": "Windows"
                                 },

--- a/unity3d_reference.py
+++ b/unity3d_reference.py
@@ -19,5 +19,13 @@ def on_cancel():
 	return
 
 def SearchFor(data):
-	url = 'http://docs.unity3d.com/ScriptReference/30_search.html?q={0}'.format(data)
-	webbrowser.open_new_tab(url)
+	defaults = sublime.load_settings('Default.sublime-settings')
+	settings = sublime.load_settings('Unity3DReference.sublime-settings')
+
+	use_local_url = settings.get('use_local_url', defaults.get('use_local_url'))
+	local_url = settings.get('local_url', defaults.get('local_url'))
+	default_url = 'http://docs.unity3d.com/ScriptReference/30_search.html'
+
+	url = use_local_url and local_url or default_url
+
+	webbrowser.open_new_tab(url + '?q={0}'.format(data))


### PR DESCRIPTION
What I suggested [here](https://github.com/talitore/Unity3DReference/issues/1). It’s disabled by default so it shouldn’t cause any issues.

The path to the docs on Windows may be invalid, I could only test on my Mac. Any help on this ?
