### PR TITLE
default_browser setting

### DIFF
--- a/Default (Linux).sublime-settings
+++ b/Default (Linux).sublime-settings
@@ -1,4 +1,5 @@
 {
   "use_local_url": false,
-  "local_url": "file:///opt/Unity/Editor/Data/Documentation/en/ScriptReference/30_search.html"
+  "local_url": "file:///opt/Unity/Editor/Data/Documentation/en/ScriptReference/30_search.html",
+  "default_browser": ""
 }

--- a/Default (OSX).sublime-settings
+++ b/Default (OSX).sublime-settings
@@ -1,4 +1,5 @@
 {
   "use_local_url": false,
-  "local_url": "file:///Applications/Unity/Documentation/html/en/ScriptReference/30_search.html"
+  "local_url": "file:///Applications/Unity/Documentation/html/en/ScriptReference/30_search.html",
+  "default_browser": ""
 }

--- a/Default (Windows).sublime-settings
+++ b/Default (Windows).sublime-settings
@@ -1,4 +1,5 @@
 {
   "use_local_url": false,
-  "local_url": "C:\\Program Files (x86)\\Unity\\Editor\\Data\\Documentation\\html\\en\\ScriptReference\\30_search.html"
+  "local_url": "C:\\Program Files (x86)\\Unity\\Editor\\Data\\Documentation\\html\\en\\ScriptReference\\30_search.html",
+  "default_browser": ""
 }

--- a/unity3d_reference.py
+++ b/unity3d_reference.py
@@ -21,11 +21,23 @@ def on_cancel():
 def SearchFor(data):
 	defaults = sublime.load_settings('Default.sublime-settings')
 	settings = sublime.load_settings('Unity3DReference.sublime-settings')
+	platform = sublime.platform()
 
 	use_local_url = settings.get('use_local_url', defaults.get('use_local_url'))
 	local_url = settings.get('local_url', defaults.get('local_url'))
 	default_url = 'http://docs.unity3d.com/ScriptReference/30_search.html'
 
+	default_browser = settings.get('default_browser', defaults.get('default_browser'))
+	if default_browser:
+		if platform == 'osx':
+			browser_path = 'open -a ' + "\"%s\"" % default_browser
+		else:
+			browser_path = "\"%s\"" % default_browser
+		browser_path += ' %s'
+		open_new_tab = webbrowser.get(browser_path).open_new_tab
+	else:
+		open_new_tab = webbrowser.open_new_tab
+
 	url = use_local_url and local_url or default_url
 
-	webbrowser.open_new_tab(url + '?q={0}'.format(data))
+	open_new_tab(url + '?q={0}'.format(data))


### PR DESCRIPTION
The plugin always opens docs in the default platform browser (e.g. Safari on OSX). I prefer Chrome, so I created a setting to specify browser executable. By default it's blank, and if it's blank the default (current) behavior is fired. But if it's filled in with something - it tries to open executable by the path defined.

Also, I would suggest you use `edit_settings` for settings editing instead of `open_file`. Not sure if it's possible with specifying the platform though, but it open both default and user settings in a split view.